### PR TITLE
Option to test authentication from the command line

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from flask_cors import CORS
 from flask_jwt_extended import JWTManager, create_access_token
 from flask_ldap3_login import LDAP3LoginManager
 
+
 def get_file_content(key, default=""):
     file_path = os.environ.get(key, "")
     if os.path.isfile(file_path):

--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@ from flask_cors import CORS
 from flask_jwt_extended import JWTManager, create_access_token
 from flask_ldap3_login import LDAP3LoginManager
 
+import logging
+logging.basicConfig(level=logging.DEBUG)
 
 def get_file_content(key, default=""):
     file_path = os.environ.get(key, "")
@@ -23,7 +25,7 @@ class Config(object):
     JWT_PRIVATE_KEY = get_file_content("JWT_PRIVATE_KEY_FILE")
     JWT_PUBLIC_KEY = get_file_content("JWT_PUBLIC_KEY_FILE")
     JWT_ACCESS_TOKEN_EXPIRES = int(
-        os.environ.get("JWT_ACCESS_TOKEN_EXPIRES", 15)
+        os.environ.get("JWT_ACCESS_TOKEN_EXPIRES", 15*60) # 15 minutes
     )
 
 
@@ -88,3 +90,12 @@ def generate_token(username, last_forever):
     else:
         token = create_access_token(identity=username)
     print(token)
+
+
+@app.cli.command()
+@click.argument('username')
+@click.argument('password')
+def test_authentication(username, password):
+    """Test authentication."""
+    ldap_response = ldap_manager.authenticate(username, password)
+    print(ldap_response.status)

--- a/app.py
+++ b/app.py
@@ -7,9 +7,6 @@ from flask_cors import CORS
 from flask_jwt_extended import JWTManager, create_access_token
 from flask_ldap3_login import LDAP3LoginManager
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
-
 def get_file_content(key, default=""):
     file_path = os.environ.get(key, "")
     if os.path.isfile(file_path):
@@ -25,7 +22,7 @@ class Config(object):
     JWT_PRIVATE_KEY = get_file_content("JWT_PRIVATE_KEY_FILE")
     JWT_PUBLIC_KEY = get_file_content("JWT_PUBLIC_KEY_FILE")
     JWT_ACCESS_TOKEN_EXPIRES = int(
-        os.environ.get("JWT_ACCESS_TOKEN_EXPIRES", 15*60) # 15 minutes
+        os.environ.get("JWT_ACCESS_TOKEN_EXPIRES", 15)
     )
 
 


### PR DESCRIPTION
This PR adds the possibility to test the LDAP configuration from the command line:
```
flask test-authentication <username> <password>
```
